### PR TITLE
[#8]Chore(GitHub): 권한 문제로 GitHub Actions 실패해 병합 후 진행하도록 수정

### DIFF
--- a/.github/workflows/automation-test.yml
+++ b/.github/workflows/automation-test.yml
@@ -10,7 +10,7 @@ name: Java CI with Gradle
 on:
   pull_request:
     branches: [ "main" ]
-  
+
 jobs:
   build:
 
@@ -78,22 +78,3 @@ jobs:
       if: always()
       with:
         report_paths: 'build/test-results/test/TEST-*.xml'
-
-  dependency-submission:
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-
-    # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
-    # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
-    - name: Generate and submit dependency graph
-      uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,46 @@
+name: dependency-submission.yml
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  dependency-submission:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Generate and submit dependency graph
+        id: dependency-submission
+        uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+      - name: Send Email Notification on Failure
+        if: failure()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: ${{ secrets.SMTP_SERVER }}
+          server_port: ${{ secrets.SMTP_PORT }}
+          username: ${{ secrets.SMTP_USER }}
+          password: ${{ secrets.SMTP_PASS }}
+          subject: "Dependency Submission Failed"
+          to: "healthy.joy.smile@gmail.com"
+          from: "GitHub Actions <@gmail.com>"
+          body: |
+            The dependency submission job failed for PR:
+            - Repository: ${{ github.repository }}
+            - PR Number: ${{ github.event.pull_request.number }}
+            - PR Title: ${{ github.event.pull_request.title }}
+
+      - name: Rollback Changes on Failure
+        if: failure()
+        run: |
+          git revert --no-commit HEAD
+          git commit -m "Revert: Dependency submission failed"
+          git push origin main

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,107 +9,90 @@ name: Java CI with Gradle
 
 on:
   pull_request:
-    branches:
-      - main
-    types:
-      - closed  # PR이 닫힐 때도 트리거
-
+    branches: [ "main" ]
+# 참고: https://ttl-blog.tistory.com/1350
+# Report 결과 쓰기 위해 필요
+permissions:
+  checks: write
+  pull-requests: write
+  
 jobs:
   build:
+
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
 
-      # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
-      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+    # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
+    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
-      - name: Build with Gradle Wrapper
-        run: ./gradlew build
+    - name: Build with Gradle Wrapper
+      run: ./gradlew build
 
-        # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
-        # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.
-        #
-        # - name: Setup Gradle
-        #   uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
-        #   with:
-        #     gradle-version: '8.9'
-        #
-        # - name: Build with Gradle 8.9
-        #   run: gradle build
+    # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
+    # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.
+    #
+    # - name: Setup Gradle
+    #   uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+    #   with:
+    #     gradle-version: '8.9'
+    #
+    # - name: Build with Gradle 8.9
+    #   run: gradle build
 
-  test:
+  test:   
+
     runs-on: ubuntu-latest
-    # 참고: https://ttl-blog.tistory.com/1350
-    # Report 결과 쓰기 위해 필요
-    permissions:
-      checks: write
-      pull-requests: write
+
     steps:
-      - uses: actions/checkout@v4
-      - name: JDK 21 세팅
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-      - name: gradlew 실행 권한 설정
-        run: chmod +x gradlew
-      - name: 테스트 진행
-        run: ./gradlew --info test
-      - name: 테스트 결과 Report # 테스트가 실패해도 Report를 보기 위해 `always`로 설정
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: 'build/test-results/**/*.xml'
-      - name: 테스트 실패 Comment
-        uses: mikepenz/action-junit-report@v3
-        if: always()
-        with:
-          report_paths: 'build/test-results/test/TEST-*.xml'
+    - uses: actions/checkout@v4
+    - name: JDK 21 세팅 
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21' 
+        distribution: 'temurin' 
+
+    - name: gradlew 실행 권한 설정 
+      run: chmod +x gradlew
+ 
+    - name: 테스트 진행 
+      run: ./gradlew --info test
+      
+    - name: 테스트 결과 Report 
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()  # 테스트가 실패해도 Report를 보기 위해 `always`로 설정
+      with:
+         files: 'build/test-results/**/*.xml'
+    
+    - name: 테스트 실패 Comment 
+      uses: mikepenz/action-junit-report@v3
+      if: always()
+      with:
+        report_paths: 'build/test-results/test/TEST-*.xml'
 
   dependency-submission:
-    if: github.event.pull_request.merged == true
+
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
 
-      # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
-      # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
-      - name: Generate and submit dependency graph
-        id: dependency-submission
-        uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582
-      - name: Send Email Notification on Failure
-        if: failure()
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: ${{ secrets.SMTP_SERVER }}
-          server_port: ${{ secrets.SMTP_PORT }}
-          username: ${{ secrets.SMTP_USER }}
-          password: ${{ secrets.SMTP_PASS }}
-          subject: "Dependency Submission Failed"
-          to: "your-email@example.com"
-          from: "GitHub Actions <your-email@example.com>"
-          body: |
-            The dependency submission job failed for PR:
-            - Repository: ${{ github.repository }}
-            - PR Number: ${{ github.event.pull_request.number }}
-            - PR Title: ${{ github.event.pull_request.title }}
-      - name: Rollback Changes on Failure
-        if: failure()
-        run: |
-          git revert --no-commit HEAD
-          git commit -m "Revert: Dependency submission failed"
-          git push origin main
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
+    # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,11 +10,6 @@ name: Java CI with Gradle
 on:
   pull_request:
     branches: [ "main" ]
-# 참고: https://ttl-blog.tistory.com/1350
-# Report 결과 쓰기 위해 필요
-permissions:
-  checks: write
-  pull-requests: write
   
 jobs:
   build:
@@ -51,6 +46,12 @@ jobs:
   test:   
 
     runs-on: ubuntu-latest
+
+    # 참고: https://ttl-blog.tistory.com/1350
+    # Report 결과 쓰기 위해 필요
+    permissions:
+      checks: write
+      pull-requests: write
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,90 +9,107 @@ name: Java CI with Gradle
 
 on:
   pull_request:
-    branches: [ "main" ]
-# 참고: https://ttl-blog.tistory.com/1350
-# Report 결과 쓰기 위해 필요
-permissions:
-  checks: write
-  pull-requests: write
-  
+    branches:
+      - main
+    types:
+      - closed  # PR이 닫힐 때도 트리거
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-    # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
-    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
+      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
 
-    - name: Build with Gradle Wrapper
-      run: ./gradlew build
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
+      - name: Build with Gradle Wrapper
+        run: ./gradlew build
 
-    # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
-    # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.
-    #
-    # - name: Setup Gradle
-    #   uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
-    #   with:
-    #     gradle-version: '8.9'
-    #
-    # - name: Build with Gradle 8.9
-    #   run: gradle build
+        # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
+        # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.
+        #
+        # - name: Setup Gradle
+        #   uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+        #   with:
+        #     gradle-version: '8.9'
+        #
+        # - name: Build with Gradle 8.9
+        #   run: gradle build
 
-  test:   
-
+  test:
     runs-on: ubuntu-latest
-
+    # 참고: https://ttl-blog.tistory.com/1350
+    # Report 결과 쓰기 위해 필요
+    permissions:
+      checks: write
+      pull-requests: write
     steps:
-    - uses: actions/checkout@v4
-    - name: JDK 21 세팅 
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21' 
-        distribution: 'temurin' 
-
-    - name: gradlew 실행 권한 설정 
-      run: chmod +x gradlew
- 
-    - name: 테스트 진행 
-      run: ./gradlew --info test
-      
-    - name: 테스트 결과 Report 
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      if: always()  # 테스트가 실패해도 Report를 보기 위해 `always`로 설정
-      with:
-         files: 'build/test-results/**/*.xml'
-    
-    - name: 테스트 실패 Comment 
-      uses: mikepenz/action-junit-report@v3
-      if: always()
-      with:
-        report_paths: 'build/test-results/test/TEST-*.xml'
+      - uses: actions/checkout@v4
+      - name: JDK 21 세팅
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: gradlew 실행 권한 설정
+        run: chmod +x gradlew
+      - name: 테스트 진행
+        run: ./gradlew --info test
+      - name: 테스트 결과 Report # 테스트가 실패해도 Report를 보기 위해 `always`로 설정
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: 'build/test-results/**/*.xml'
+      - name: 테스트 실패 Comment
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: 'build/test-results/test/TEST-*.xml'
 
   dependency-submission:
-
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'temurin'
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
 
-    # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
-    # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
-    - name: Generate and submit dependency graph
-      uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
+      # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
+      - name: Generate and submit dependency graph
+        id: dependency-submission
+        uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582
+      - name: Send Email Notification on Failure
+        if: failure()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: ${{ secrets.SMTP_SERVER }}
+          server_port: ${{ secrets.SMTP_PORT }}
+          username: ${{ secrets.SMTP_USER }}
+          password: ${{ secrets.SMTP_PASS }}
+          subject: "Dependency Submission Failed"
+          to: "your-email@example.com"
+          from: "GitHub Actions <your-email@example.com>"
+          body: |
+            The dependency submission job failed for PR:
+            - Repository: ${{ github.repository }}
+            - PR Number: ${{ github.event.pull_request.number }}
+            - PR Title: ${{ github.event.pull_request.title }}
+      - name: Rollback Changes on Failure
+        if: failure()
+        run: |
+          git revert --no-commit HEAD
+          git commit -m "Revert: Dependency submission failed"
+          git push origin main


### PR DESCRIPTION
## 작업 요약
- fork repository라 권한 문제로 GitHub Actions dependency-submission 실패해 병합 후 진행하도록 수정 
resolve #8 

### 스크린샷
<img width="609" alt="스크린샷 2025-05-11 02 56 58" src="https://github.com/user-attachments/assets/db2d538c-771a-44a0-9082-20b8bddf4ed1" />


## 작업 설명

### AS-IS
X

### TO-BE
- 홈페이지의 github chat과 대화해 보안을 위해 권한을 추가하지는 않고, 병합 이후 확인하도록 함.
- closed 시 dependency-submission 확인, 실패 시 메일 알림과 roll back 진행.

## 이 PR이 merge된 후에 해야 할 일
- PR 보냈을 때 github Actions가 잘 돌아가는지 확인 필요.

## 리뷰 요구사항
- 확인이 필요해 우선 merge 진행 예정. 의견 있다면 댓글 달아주세요. 추후 확인하겠습니다.
- + GitHub 내용이라 Chore로 했는데, 이게 계속.. 고민이네요... 그런데, Fix, Deploy는 여전히 아닌 것 같아서.. ^__^ 이대로 두었습니다. 좋은 의견 환영.

## 참고
- [노션 문서](https://www.notion.so/hannanana/GitHub-Actions-1ef33717f913808c9453cc0ad7787ecd?pvs=4)

## 확인 사항
- [x] 내 코드에 대해 self-review를 진행했는지?
- [x] 내 코드가 project 규칙에 만족하는지?
- [x] sonarlint, IDE, log 등에서 새로운 warning이 없는 걸 확인했는지?
- [ ] 적절한 테스트 코드를 추가했는지?
- [x] 모든 테스트에 통과하는 걸 확인했는지?
- [ ] 필요한 문서 생성/수정이 진행되었는지?
