### PR TITLE
[#8]Chore(GitHub): 권한 문제로 GitHub Actions test 댓글 생성 실패해 권한 수정

### DIFF
--- a/.github/workflows/automation-test.yml
+++ b/.github/workflows/automation-test.yml
@@ -76,8 +76,15 @@ jobs:
       with:
          files: 'build/test-results/**/*.xml'
     
-    - name: 테스트 실패 Comment 
-      uses: mikepenz/action-junit-report@v3
-      if: always()
+    - name: 테스트 Comment for clone repo
+      uses: mikepenz/action-junit-report@v5
+      if: ${{ (github.event.pull_request.head.repo.full_name == github.repository) }}
       with:
-        report_paths: 'build/test-results/test/TEST-*.xml'
+        report_paths: '**/build/test-results/test/TEST-*.xml'
+
+      # 참고: https://github.com/mikepenz/action-junit-report
+    - name: Write out Unit Test report annotation for forked repo
+      if: ${{ (github.event.pull_request.head.repo.full_name != github.repository) }}
+      uses: mikepenz/action-junit-report@v5
+      with:
+        annotate_only: true # forked repo cannot write to checks so just do annotations

--- a/.github/workflows/automation-test.yml
+++ b/.github/workflows/automation-test.yml
@@ -35,7 +35,7 @@ jobs:
     # for test report comment for fork repo
     # ref: https://github.com/mikepenz/action-junit-report
     - name: Upload Test Report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always() # always run even if the previous step fails
       with:
         name: junit-test-results

--- a/.github/workflows/automation-test.yml
+++ b/.github/workflows/automation-test.yml
@@ -76,15 +76,14 @@ jobs:
       with:
          files: 'build/test-results/**/*.xml'
     
-    - name: 테스트 Comment for clone repo
+    - name: 테스트 Comment - clone repo
       uses: mikepenz/action-junit-report@v5
-      if: ${{ (github.event.pull_request.head.repo.full_name == github.repository) }}
+      if: ${{ always() &&  (github.event.pull_request.head.repo.full_name == github.repository) }}
       with:
         report_paths: '**/build/test-results/test/TEST-*.xml'
 
-      # 참고: https://github.com/mikepenz/action-junit-report
     - name: Write out Unit Test report annotation for forked repo
-      if: ${{ (github.event.pull_request.head.repo.full_name != github.repository) }}
+      if: ${{ failure() &&  (github.event.pull_request.head.repo.full_name != github.repository) }}
       uses: mikepenz/action-junit-report@v5
       with:
         annotate_only: true # forked repo cannot write to checks so just do annotations

--- a/.github/workflows/automation-test.yml
+++ b/.github/workflows/automation-test.yml
@@ -32,16 +32,6 @@ jobs:
     - name: Build with Gradle Wrapper
       run: ./gradlew build
 
-    # for test report comment for fork repo
-    # ref: https://github.com/mikepenz/action-junit-report
-    - name: Upload Test Report
-      uses: actions/upload-artifact@v4
-      if: always() # always run even if the previous step fails
-      with:
-        name: junit-test-results
-        path: '**/build/test-results/test/TEST-*.xml'
-        retention-days: 1
-
     # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
     # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.
     #

--- a/.github/workflows/automation-test.yml
+++ b/.github/workflows/automation-test.yml
@@ -49,8 +49,11 @@ jobs:
 
     # 참고: https://ttl-blog.tistory.com/1350
     # Report 결과 쓰기 위해 필요
+    # 참고: https://github.com/mikepenz/action-junit-report/issues/23
     permissions:
+      contents: read
       checks: write
+      id-token: write
       pull-requests: write
 
     steps:

--- a/.github/workflows/automation-test.yml
+++ b/.github/workflows/automation-test.yml
@@ -32,6 +32,16 @@ jobs:
     - name: Build with Gradle Wrapper
       run: ./gradlew build
 
+    # for test report comment for fork repo
+    # ref: https://github.com/mikepenz/action-junit-report
+    - name: Upload Test Report
+      uses: actions/upload-artifact@v3
+      if: always() # always run even if the previous step fails
+      with:
+        name: junit-test-results
+        path: '**/build/test-results/test/TEST-*.xml'
+        retention-days: 1
+
     # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
     # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.
     #

--- a/.github/workflows/fork-pr-test-report.yml
+++ b/.github/workflows/fork-pr-test-report.yml
@@ -1,7 +1,7 @@
 name: fork-pr-test-report.yml
 on:
   workflow_run:
-    workflows: [ build ]
+    workflows: [ save-build ]
     types: [ completed ]
 
 permissions:

--- a/.github/workflows/fork-pr-test-report.yml
+++ b/.github/workflows/fork-pr-test-report.yml
@@ -1,0 +1,24 @@
+name: fork-pr-test-report.yml
+on:
+  workflow_run:
+    workflows: [ build ]
+    types: [ completed ]
+
+permissions:
+  checks: write
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Test Report
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          name: junit-test-results
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        with:
+          commit: ${{github.event.workflow_run.head_sha}}
+          report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/save-build.yml
+++ b/.github/workflows/save-build.yml
@@ -10,8 +10,19 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-      - name: Build and Run Tests
-        run: # execute your tests generating test results
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: gradlew 실행 권한 설정
+        run: chmod +x gradlew
+
+      - name: 테스트 진행
+        run: ./gradlew --info test
+
       - name: Upload Test Report
         uses: actions/upload-artifact@v4
         if: always() # always run even if the previous step fails

--- a/.github/workflows/save-build.yml
+++ b/.github/workflows/save-build.yml
@@ -1,0 +1,21 @@
+name: save-build
+
+on:
+  pull_request:
+
+jobs:
+  save-build:
+    name: Build and Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Build and Run Tests
+        run: # execute your tests generating test results
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: junit-test-results
+          path: '**/build/test-results/test/TEST-*.xml'
+          retention-days: 1

--- a/src/test/java/diffbydevs/velog_clone/VelogCloneApplicationTests.java
+++ b/src/test/java/diffbydevs/velog_clone/VelogCloneApplicationTests.java
@@ -10,4 +10,9 @@ class VelogCloneApplicationTests {
 	void contextLoads() {
 	}
 
+	@Test
+	void testFail() throws IllegalAccessException {
+		throw new IllegalAccessException();
+	}
+
 }


### PR DESCRIPTION
## 작업 요약
- test 댓글 권한이 없어 권한 추가
- -> clone으로 진행 시 가능하고, 우선 실패하면 merge 불가능하기 때문에 이대로 두기로 결정.
- permission은 댓글 위해 권한이 그렇게 필요하다고 해([issue 확인](https://github.com/mikepenz/action-junit-report/issues/23)) 이대로 merge 진행.
- 하려고 했으나 [메인 Readme](https://github.com/mikepenz/action-junit-report)를 확인하니, 방법 2개가 있어서 우선 시도.

### 스크린샷 
<img width="626" alt="스크린샷 2025-05-11 03 44 15" src="https://github.com/user-attachments/assets/2a2ed397-b20c-4b64-8add-8084ed500a5c" />

## 작업 설명

### AS-IS
```
    permissions:
      checks: write
      pull-requests: write

``` 

### TO-BE
```
    permissions:
      contents: read
      checks: write
      id-token: write
      pull-requests: write
``` 

-

## 이 PR이 merge된 후에 해야 할 일
- test 댓글 생성 확인하기

## 참고
- [노션 문서](https://www.notion.so/hannanana/GitHub-Actions-1ef33717f913808c9453cc0ad7787ecd?pvs=4)

## 확인 사항

- [ ] 내 코드에 대해 self-review를 진행했는지?
- [ ] 내 코드가 project 규칙에 만족하는지?
- [ ] sonarlint, IDE, log 등에서 새로운 warning이 없는 걸 확인했는지?
- [ ] 적절한 테스트 코드를 추가했는지?
- [ ] 모든 테스트에 통과하는 걸 확인했는지?
- [ ] 필요한 문서 생성/수정이 진행되었는지?
